### PR TITLE
Progress bar 컴포넌트 퍼블리싱

### DIFF
--- a/client/src/shared/components/ProgressBar.tsx
+++ b/client/src/shared/components/ProgressBar.tsx
@@ -51,7 +51,7 @@ const ProgressBar = ({
   size = "md",
 }: ProgressBarProps) => {
   // value가 주어지지 않았을 경우 current와 max를 이용해 계산
-  const computedValue = computeValue(value ?? 0, current, max);
+  const computedValue = computeValue(value, current, max);
 
   const { root, track, fill, label } = progressBarVariant({
     size,
@@ -81,7 +81,7 @@ const ProgressBar = ({
 
 export default ProgressBar;
 
-const computeValue = (value: number, current?: number, max?: number) => {
+const computeValue = (value?: number, current?: number, max?: number) => {
   if (value !== undefined) {
     return value;
   } else if (current !== undefined && max !== undefined && max !== 0) {

--- a/client/src/shared/components/ProgressBar.tsx
+++ b/client/src/shared/components/ProgressBar.tsx
@@ -51,7 +51,7 @@ const ProgressBar = ({
   size = "md",
 }: ProgressBarProps) => {
   // value가 주어지지 않았을 경우 current와 max를 이용해 계산
-  let computedValue = computeValue(value ?? 0, current, max);
+  const computedValue = computeValue(value ?? 0, current, max);
 
   const { root, track, fill, label } = progressBarVariant({
     size,

--- a/client/src/shared/components/ProgressBar.tsx
+++ b/client/src/shared/components/ProgressBar.tsx
@@ -1,0 +1,91 @@
+import { tv } from "tailwind-variants";
+import { useEffect, useState } from "react";
+
+const progressBarVariant = tv({
+  slots: {
+    root: "flex items-center justify-between gap-1",
+    track:
+      "relative w-full h-[.5625rem] bg-gray-300 rounded-[50px] overflow-hidden",
+    fill: "rounded-[50px] absolute top-0 left-0 h-full bg-gradient-to-r from-[#26caba] to-[#0850fd] transition-all duration-500",
+    label: "text-right",
+  },
+  variants: {
+    size: {
+      md: {
+        root: "w-[29.5rem]",
+      },
+      lg: {
+        root: "w-[39rem]",
+      },
+    },
+    type: {
+      percent: {
+        label: "typo-title-5 text-black",
+      },
+      ratio: {
+        label: "text-white typo-body-5",
+      },
+    },
+  },
+  defaultVariants: {
+    size: "md",
+    type: "percent",
+  },
+});
+
+interface ProgressBarProps {
+  value?: number;
+  current?: number;
+  max?: number;
+  labelText?: string;
+  type?: "percent" | "ratio";
+  size?: "md" | "lg";
+}
+
+const ProgressBar = ({
+  value,
+  current,
+  max,
+  labelText,
+  type,
+  size = "md",
+}: ProgressBarProps) => {
+  // value가 주어지지 않았을 경우 current와 max를 이용해 계산
+  let computedValue = computeValue(value ?? 0, current, max);
+
+  const { root, track, fill, label } = progressBarVariant({
+    size,
+    type,
+  });
+
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    setProgress(computedValue);
+  }, [computedValue]);
+
+  const defaultLabel =
+    type === "ratio" && current !== undefined && max !== undefined
+      ? `${current}/${max}`
+      : `${Math.round(computedValue)}%`;
+
+  return (
+    <div className={root()}>
+      <div className={track()}>
+        <div className={fill()} style={{ width: `${progress}%` }} />
+      </div>
+      <span className={label()}>{labelText ?? defaultLabel}</span>
+    </div>
+  );
+};
+
+export default ProgressBar;
+
+const computeValue = (value: number, current?: number, max?: number) => {
+  if (value !== undefined) {
+    return value;
+  } else if (current !== undefined && max !== undefined && max !== 0) {
+    return (current / max) * 100;
+  }
+  return 0;
+};


### PR DESCRIPTION
percentage 표시 or ratio 표시

## 🔷 Github Issue ID

[Closes #77 ]

---
## 📌 작업 내용 및 특이사항

![progress bar](https://github.com/user-attachments/assets/b9e83abd-2f44-4a6f-bbe4-209241ce31a3)
**type**
- percentage: 오른쪽 라벨이 %로 표시됩니다.
- ratio: 오른쪽 라벨이 now/max로 표시됩니다.

**size**
- 두 가지 size(lg, md) 중 선택할 수 있습니다.
---
## 📚 참고사항

**사용 예시**
``` tsx
      {/* 퍼센트만 표시 */}
      <ProgressBar value={percent} type={"percent"} size={"lg"}/>

      {/* 비율(5/8)로 표시 */}
      <ProgressBar  type={"ratio"} current={5} max={8} />
```

