### PR TITLE
[FEATURE] - 위젯 설정 관련 수정사항 반영 및 업데이트 기능 구현

### DIFF
--- a/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
@@ -27,7 +27,8 @@ public class WidgetSettingController {
     public List<WidgetSettingResponse> updateWidgetSettings(
             @Parameter(hidden = true) @RequestAttribute("userId") Long userId,
             @Parameter(description = "수정할 강의 ID") @PathVariable Long lectureId,
-            @Parameter(description = "수정할 위젯 설정 정보") @Valid @RequestBody WidgetSettingUpdateRequest request) {
+            @Parameter(description = "수정할 위젯 설정 정보") @Valid @RequestBody
+                    WidgetSettingUpdateRequest request) {
         return widgetSettingService.updateWidgetSettings(userId, lectureId, request);
     }
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
@@ -27,7 +27,7 @@ public class WidgetSettingController {
     public List<WidgetSettingResponse> updateWidgetSettings(
             @Parameter(hidden = true) @RequestAttribute("userId") Long userId,
             @Parameter(description = "수정할 강의 ID") @PathVariable Long lectureId,
-            @Parameter(hidden = true) @Valid @RequestBody WidgetSettingUpdateRequest request) {
+            @Parameter(description = "수정할 위젯 설정 정보") @Valid @RequestBody WidgetSettingUpdateRequest request) {
         return widgetSettingService.updateWidgetSettings(userId, lectureId, request);
     }
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
@@ -2,20 +2,16 @@ package com.seniclass.server.domain.lecture.controller;
 
 import com.seniclass.server.domain.auth.domain.RequireAuth;
 import com.seniclass.server.domain.auth.enums.UserRole;
-import com.seniclass.server.domain.lecture.dto.request.LectureUpdateRequest;
 import com.seniclass.server.domain.lecture.dto.request.WidgetSettingUpdateRequest;
-import com.seniclass.server.domain.lecture.dto.response.LectureResponse;
 import com.seniclass.server.domain.lecture.dto.response.WidgetSettingResponse;
 import com.seniclass.server.domain.lecture.service.WidgetSettingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "WidgetSetting", description = "위젯 설정 관리 API")
 @RestController

--- a/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
@@ -21,7 +21,7 @@ public class WidgetSettingController {
 
     private final WidgetSettingService widgetSettingService;
 
-    @Operation(summary = "위젯 설정 수정", description = "강사가 본인의 강의 위젯 설정을 수정합니다. TEACHER 권한 필요.")
+    @Operation(summary = "위젯 설정 수정 (강사)", description = "강사가 본인의 강의 위젯 설정을 수정합니다. TEACHER 권한 필요.")
     @PutMapping
     @RequireAuth(roles = {UserRole.TEACHER})
     public List<WidgetSettingResponse> updateWidgetSettings(

--- a/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/controller/WidgetSettingController.java
@@ -1,0 +1,37 @@
+package com.seniclass.server.domain.lecture.controller;
+
+import com.seniclass.server.domain.auth.domain.RequireAuth;
+import com.seniclass.server.domain.auth.enums.UserRole;
+import com.seniclass.server.domain.lecture.dto.request.LectureUpdateRequest;
+import com.seniclass.server.domain.lecture.dto.request.WidgetSettingUpdateRequest;
+import com.seniclass.server.domain.lecture.dto.response.LectureResponse;
+import com.seniclass.server.domain.lecture.dto.response.WidgetSettingResponse;
+import com.seniclass.server.domain.lecture.service.WidgetSettingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "WidgetSetting", description = "위젯 설정 관리 API")
+@RestController
+@RequestMapping("/lectures/{lectureId}/widget-settings")
+@RequiredArgsConstructor
+public class WidgetSettingController {
+
+    private final WidgetSettingService widgetSettingService;
+
+    @Operation(summary = "위젯 설정 수정", description = "강사가 본인의 강의 위젯 설정을 수정합니다. TEACHER 권한 필요.")
+    @PutMapping
+    @RequireAuth(roles = {UserRole.TEACHER})
+    public List<WidgetSettingResponse> updateWidgetSettings(
+            @Parameter(hidden = true) @RequestAttribute("userId") Long userId,
+            @Parameter(description = "수정할 강의 ID") @PathVariable Long lectureId,
+            @Parameter(hidden = true) @Valid @RequestBody WidgetSettingUpdateRequest request) {
+        return widgetSettingService.updateWidgetSettings(userId, lectureId, request);
+    }
+}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/domain/WidgetSetting.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/domain/WidgetSetting.java
@@ -75,8 +75,7 @@ public class WidgetSetting extends BaseTimeEntity {
                 .build();
     }
 
-    public void updateWidgetSettingFromSpec(
-            WidgetSpec spec) {
+    public void updateWidgetSettingFromSpec(WidgetSpec spec) {
         this.widgetType = spec.type();
         this.rowPosition = spec.row();
         this.colPosition = spec.col();

--- a/server/src/main/java/com/seniclass/server/domain/lecture/domain/WidgetSetting.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/domain/WidgetSetting.java
@@ -1,6 +1,7 @@
 package com.seniclass.server.domain.lecture.domain;
 
 import com.seniclass.server.domain.common.model.BaseTimeEntity;
+import com.seniclass.server.domain.lecture.enums.WidgetSize;
 import com.seniclass.server.domain.lecture.enums.WidgetType;
 import jakarta.persistence.*;
 import jakarta.persistence.Entity;
@@ -30,10 +31,7 @@ public class WidgetSetting extends BaseTimeEntity {
     private Integer colPosition;
 
     @Column(nullable = false)
-    private Integer width;
-
-    @Column(nullable = false)
-    private Integer height;
+    private WidgetSize widgetSize;
 
     @Column(nullable = false)
     private Boolean visible;
@@ -48,15 +46,13 @@ public class WidgetSetting extends BaseTimeEntity {
             WidgetType widgetType,
             Integer rowPosition,
             Integer colPosition,
-            Integer width,
-            Integer height,
+            WidgetSize widgetSize,
             Boolean visible,
             Lecture lecture) {
         this.widgetType = widgetType;
         this.rowPosition = rowPosition;
         this.colPosition = colPosition;
-        this.width = width;
-        this.height = height;
+        this.widgetSize = widgetSize;
         this.visible = visible;
         this.lecture = lecture;
     }
@@ -65,16 +61,14 @@ public class WidgetSetting extends BaseTimeEntity {
             WidgetType widgetType,
             Integer rowPosition,
             Integer colPosition,
-            Integer width,
-            Integer height,
+            WidgetSize widgetSize,
             Boolean visible,
             Lecture lecture) {
         return WidgetSetting.builder()
                 .widgetType(widgetType)
                 .rowPosition(rowPosition)
                 .colPosition(colPosition)
-                .width(width)
-                .height(height)
+                .widgetSize(widgetSize)
                 .visible(visible)
                 .lecture(lecture)
                 .build();

--- a/server/src/main/java/com/seniclass/server/domain/lecture/domain/WidgetSetting.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/domain/WidgetSetting.java
@@ -1,6 +1,7 @@
 package com.seniclass.server.domain.lecture.domain;
 
 import com.seniclass.server.domain.common.model.BaseTimeEntity;
+import com.seniclass.server.domain.lecture.dto.WidgetSpec;
 import com.seniclass.server.domain.lecture.enums.WidgetSize;
 import com.seniclass.server.domain.lecture.enums.WidgetType;
 import jakarta.persistence.*;
@@ -72,5 +73,14 @@ public class WidgetSetting extends BaseTimeEntity {
                 .visible(visible)
                 .lecture(lecture)
                 .build();
+    }
+
+    public void updateWidgetSettingFromSpec(
+            WidgetSpec spec) {
+        this.widgetType = spec.type();
+        this.rowPosition = spec.row();
+        this.colPosition = spec.col();
+        this.widgetSize = spec.widgetSize();
+        this.visible = spec.visible();
     }
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
@@ -2,10 +2,24 @@ package com.seniclass.server.domain.lecture.dto;
 
 import com.seniclass.server.domain.lecture.enums.WidgetSize;
 import com.seniclass.server.domain.lecture.enums.WidgetType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+import static com.seniclass.server.domain.lecture.enums.WidgetType.*;
+
+@Schema(description = "위젯 스펙 DTO")
 public record WidgetSpec(
-        WidgetType type,
-        Integer row,
-        Integer col,
-        WidgetSize widgetSize,
-        Boolean visible) {}
+        @Schema(description = "위젯 타입", example = "ATTENDANCE" , allowableValues = {
+                "QNA",
+                "SUBMISSION",
+                "TEACHER_INFO",
+                "REVIEW",
+                "NEXT_LECTURE",
+                "STUDENTS_STATUS"
+        }) WidgetType type,
+        @Schema(description = "행 위치", example = "1") Integer row,
+        @Schema(description = "열 위치", example = "1") Integer col,
+        @Schema(description = "위젯 크기", example = "SMALL", allowableValues = {
+                "SMALL",
+                "LARGE"
+        }) WidgetSize widgetSize,
+        @Schema(description = "표시 여부", example = "true") Boolean visible) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
@@ -1,11 +1,11 @@
 package com.seniclass.server.domain.lecture.dto;
 
+import com.seniclass.server.domain.lecture.enums.WidgetSize;
 import com.seniclass.server.domain.lecture.enums.WidgetType;
 
 public record WidgetSpec(
         WidgetType type,
         Integer row,
         Integer col,
-        Integer height,
-        Integer width,
+        WidgetSize widgetSize,
         Boolean visible) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
@@ -1,25 +1,30 @@
 package com.seniclass.server.domain.lecture.dto;
 
+import static com.seniclass.server.domain.lecture.enums.WidgetType.*;
+
 import com.seniclass.server.domain.lecture.enums.WidgetSize;
 import com.seniclass.server.domain.lecture.enums.WidgetType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import static com.seniclass.server.domain.lecture.enums.WidgetType.*;
-
 @Schema(description = "위젯 스펙 DTO")
 public record WidgetSpec(
-        @Schema(description = "위젯 타입", example = "ATTENDANCE" , allowableValues = {
-                "QNA",
-                "SUBMISSION",
-                "TEACHER_INFO",
-                "REVIEW",
-                "NEXT_LECTURE",
-                "STUDENTS_STATUS"
-        }) WidgetType type,
+        @Schema(
+                        description = "위젯 타입",
+                        example = "ATTENDANCE",
+                        allowableValues = {
+                            "QNA",
+                            "SUBMISSION",
+                            "TEACHER_INFO",
+                            "REVIEW",
+                            "NEXT_LECTURE",
+                            "STUDENTS_STATUS"
+                        })
+                WidgetType type,
         @Schema(description = "행 위치", example = "1") Integer row,
         @Schema(description = "열 위치", example = "1") Integer col,
-        @Schema(description = "위젯 크기", example = "SMALL", allowableValues = {
-                "SMALL",
-                "LARGE"
-        }) WidgetSize widgetSize,
+        @Schema(
+                        description = "위젯 크기",
+                        example = "SMALL",
+                        allowableValues = {"SMALL", "LARGE"})
+                WidgetSize widgetSize,
         @Schema(description = "표시 여부", example = "true") Boolean visible) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
@@ -21,16 +21,24 @@ public record WidgetSpec(
                             "REVIEW",
                             "NEXT_LECTURE",
                             "STUDENTS_STATUS"
-                        }) @NotNull(message = "위젯 타입은 필수입니다.")
+                        })
+                @NotNull(message = "위젯 타입은 필수입니다.")
                 WidgetType type,
-        @Schema(description = "행 위치", example = "1") @NotNull(message = "row 값은 필수입니다.") @Max(value = 5 , message = "row 값은 5이하여야 합니다.") @Min(value = 0, message = "row 값은 0 이상이어야 합니다.") Integer row,
-        @Schema(description = "열 위치", example = "1") @NotNull(message = "col 값은 필수입니다.") @Max(value = 3 , message = "row 값은 3이하여야 합니다.") @Min(value = 0, message = "col 값은 0 이상이어야 합니다.")Integer col,
+        @Schema(description = "행 위치", example = "1")
+                @NotNull(message = "row 값은 필수입니다.")
+                @Max(value = 5, message = "row 값은 5이하여야 합니다.")
+                @Min(value = 0, message = "row 값은 0 이상이어야 합니다.")
+                Integer row,
+        @Schema(description = "열 위치", example = "1")
+                @NotNull(message = "col 값은 필수입니다.")
+                @Max(value = 3, message = "row 값은 3이하여야 합니다.")
+                @Min(value = 0, message = "col 값은 0 이상이어야 합니다.")
+                Integer col,
         @Schema(
                         description = "위젯 크기",
                         example = "SMALL",
                         allowableValues = {"SMALL", "LARGE"})
-        @NotNull(message = "widgetSize 값은 필수입니다.")
+                @NotNull(message = "widgetSize 값은 필수입니다.")
                 WidgetSize widgetSize,
-        @Schema(description = "표시 여부", example = "true")
-        @NotNull(message = "표시 여부 값은 필수입니다.")
-        Boolean visible) {}
+        @Schema(description = "표시 여부", example = "true") @NotNull(message = "표시 여부 값은 필수입니다.")
+                Boolean visible) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/WidgetSpec.java
@@ -5,12 +5,15 @@ import static com.seniclass.server.domain.lecture.enums.WidgetType.*;
 import com.seniclass.server.domain.lecture.enums.WidgetSize;
 import com.seniclass.server.domain.lecture.enums.WidgetType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "위젯 스펙 DTO")
 public record WidgetSpec(
         @Schema(
                         description = "위젯 타입",
-                        example = "ATTENDANCE",
+                        example = "QNA",
                         allowableValues = {
                             "QNA",
                             "SUBMISSION",
@@ -18,13 +21,16 @@ public record WidgetSpec(
                             "REVIEW",
                             "NEXT_LECTURE",
                             "STUDENTS_STATUS"
-                        })
+                        }) @NotNull(message = "위젯 타입은 필수입니다.")
                 WidgetType type,
-        @Schema(description = "행 위치", example = "1") Integer row,
-        @Schema(description = "열 위치", example = "1") Integer col,
+        @Schema(description = "행 위치", example = "1") @NotNull(message = "row 값은 필수입니다.") @Max(value = 5 , message = "row 값은 5이하여야 합니다.") @Min(value = 0, message = "row 값은 0 이상이어야 합니다.") Integer row,
+        @Schema(description = "열 위치", example = "1") @NotNull(message = "col 값은 필수입니다.") @Max(value = 3 , message = "row 값은 3이하여야 합니다.") @Min(value = 0, message = "col 값은 0 이상이어야 합니다.")Integer col,
         @Schema(
                         description = "위젯 크기",
                         example = "SMALL",
                         allowableValues = {"SMALL", "LARGE"})
+        @NotNull(message = "widgetSize 값은 필수입니다.")
                 WidgetSize widgetSize,
-        @Schema(description = "표시 여부", example = "true") Boolean visible) {}
+        @Schema(description = "표시 여부", example = "true")
+        @NotNull(message = "표시 여부 값은 필수입니다.")
+        Boolean visible) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
@@ -2,9 +2,12 @@ package com.seniclass.server.domain.lecture.dto.request;
 
 import com.seniclass.server.domain.lecture.dto.WidgetSpec;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
 import java.util.LinkedHashMap;
 
 @Schema(description = "위젯 설정 수정 요청 DTO")
 public record WidgetSettingUpdateRequest(
         @Schema(description = "위젯 설정 맵 (Key: WidgetSettingId, Value: 위젯 스펙)")
-                LinkedHashMap<Long, WidgetSpec> widgetSettings) {}
+                @NotNull(message = "위젯 세팅 값은 필수입니다.") @NotEmpty(message = "위젯 세팅 값은 비어있을 수 없습니다.") LinkedHashMap<Long, WidgetSpec> widgetSettings) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
@@ -4,12 +4,11 @@ import com.seniclass.server.domain.lecture.dto.WidgetSpec;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-
 import java.util.ArrayList;
 
 @Schema(description = "위젯 설정 수정 요청 DTO")
 public record WidgetSettingUpdateRequest(
         @Schema(description = "위젯 설정 맵 (Key: WidgetSettingId, Value: 위젯 스펙)")
                 @NotNull(message = "위젯 세팅 값은 필수입니다.")
-        @Size(min = 6, max = 6, message = "위젯 세팅은 정확히 6개여야 합니다.")
-        ArrayList<WidgetSpec> widgetSpecs) {}
+                @Size(min = 6, max = 6, message = "위젯 세팅은 정확히 6개여야 합니다.")
+                ArrayList<WidgetSpec> widgetSpecs) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.seniclass.server.domain.lecture.dto.request;
+
+import com.seniclass.server.domain.lecture.dto.WidgetSpec;
+
+import java.util.LinkedHashMap;
+
+public record WidgetSettingUpdateRequest(
+        LinkedHashMap<Long, WidgetSpec> widgetSettings
+        ) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
@@ -1,9 +1,12 @@
 package com.seniclass.server.domain.lecture.dto.request;
 
 import com.seniclass.server.domain.lecture.dto.WidgetSpec;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.LinkedHashMap;
 
+@Schema(description = "위젯 설정 수정 요청 DTO")
 public record WidgetSettingUpdateRequest(
+        @Schema(description = "위젯 설정 맵 (Key: WidgetSettingId, Value: 위젯 스펙)")
         LinkedHashMap<Long, WidgetSpec> widgetSettings
         ) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
@@ -2,11 +2,9 @@ package com.seniclass.server.domain.lecture.dto.request;
 
 import com.seniclass.server.domain.lecture.dto.WidgetSpec;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.LinkedHashMap;
 
 @Schema(description = "위젯 설정 수정 요청 DTO")
 public record WidgetSettingUpdateRequest(
         @Schema(description = "위젯 설정 맵 (Key: WidgetSettingId, Value: 위젯 스펙)")
-        LinkedHashMap<Long, WidgetSpec> widgetSettings
-        ) {}
+                LinkedHashMap<Long, WidgetSpec> widgetSettings) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
@@ -4,10 +4,11 @@ import com.seniclass.server.domain.lecture.dto.WidgetSpec;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-
 import java.util.LinkedHashMap;
 
 @Schema(description = "위젯 설정 수정 요청 DTO")
 public record WidgetSettingUpdateRequest(
         @Schema(description = "위젯 설정 맵 (Key: WidgetSettingId, Value: 위젯 스펙)")
-                @NotNull(message = "위젯 세팅 값은 필수입니다.") @NotEmpty(message = "위젯 세팅 값은 비어있을 수 없습니다.") LinkedHashMap<Long, WidgetSpec> widgetSettings) {}
+                @NotNull(message = "위젯 세팅 값은 필수입니다.")
+                @NotEmpty(message = "위젯 세팅 값은 비어있을 수 없습니다.")
+                LinkedHashMap<Long, WidgetSpec> widgetSettings) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/request/WidgetSettingUpdateRequest.java
@@ -2,13 +2,14 @@ package com.seniclass.server.domain.lecture.dto.request;
 
 import com.seniclass.server.domain.lecture.dto.WidgetSpec;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.LinkedHashMap;
+import jakarta.validation.constraints.Size;
+
+import java.util.ArrayList;
 
 @Schema(description = "위젯 설정 수정 요청 DTO")
 public record WidgetSettingUpdateRequest(
         @Schema(description = "위젯 설정 맵 (Key: WidgetSettingId, Value: 위젯 스펙)")
                 @NotNull(message = "위젯 세팅 값은 필수입니다.")
-                @NotEmpty(message = "위젯 세팅 값은 비어있을 수 없습니다.")
-                LinkedHashMap<Long, WidgetSpec> widgetSettings) {}
+        @Size(min = 6, max = 6, message = "위젯 세팅은 정확히 6개여야 합니다.")
+        ArrayList<WidgetSpec> widgetSpecs) {}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/WidgetSettingResponse.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/WidgetSettingResponse.java
@@ -8,8 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "위젯 설정 정보 응답 DTO")
 public record WidgetSettingResponse(
         @Schema(description = "위젯 설정 ID", example = "1") Long id,
-        @Schema(description = "위젯 타입", example = "SUBMISSION" +
-                "") WidgetType widgetType,
+        @Schema(description = "위젯 타입", example = "SUBMISSION" + "") WidgetType widgetType,
         @Schema(description = "행 위치", example = "1") Integer rowPosition,
         @Schema(description = "열 위치", example = "1") Integer colPosition,
         @Schema(description = "위젯 크기", example = "SMALL") WidgetSize widgetSize,

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/WidgetSettingResponse.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/WidgetSettingResponse.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "위젯 설정 정보 응답 DTO")
 public record WidgetSettingResponse(
         @Schema(description = "위젯 설정 ID", example = "1") Long id,
-        @Schema(description = "위젯 타입", example = "SUBMISSION" + "") WidgetType widgetType,
+        @Schema(description = "위젯 타입", example = "SUBMISSION") WidgetType widgetType,
         @Schema(description = "행 위치", example = "1") Integer rowPosition,
         @Schema(description = "열 위치", example = "1") Integer colPosition,
         @Schema(description = "위젯 크기", example = "SMALL") WidgetSize widgetSize,

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/WidgetSettingResponse.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/WidgetSettingResponse.java
@@ -8,7 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "위젯 설정 정보 응답 DTO")
 public record WidgetSettingResponse(
         @Schema(description = "위젯 설정 ID", example = "1") Long id,
-        @Schema(description = "위젯 타입", example = "SUBMISSION") WidgetType widgetType,
+        @Schema(description = "위젯 타입", example = "SUBMISSION" +
+                "") WidgetType widgetType,
         @Schema(description = "행 위치", example = "1") Integer rowPosition,
         @Schema(description = "열 위치", example = "1") Integer colPosition,
         @Schema(description = "위젯 크기", example = "SMALL") WidgetSize widgetSize,

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/WidgetSettingResponse.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/WidgetSettingResponse.java
@@ -1,0 +1,27 @@
+package com.seniclass.server.domain.lecture.dto.response;
+
+import com.seniclass.server.domain.lecture.domain.WidgetSetting;
+import com.seniclass.server.domain.lecture.enums.WidgetSize;
+import com.seniclass.server.domain.lecture.enums.WidgetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "위젯 설정 정보 응답 DTO")
+public record WidgetSettingResponse(
+        @Schema(description = "위젯 설정 ID", example = "1") Long id,
+        @Schema(description = "위젯 타입", example = "SUBMISSION") WidgetType widgetType,
+        @Schema(description = "행 위치", example = "1") Integer rowPosition,
+        @Schema(description = "열 위치", example = "1") Integer colPosition,
+        @Schema(description = "위젯 크기", example = "SMALL") WidgetSize widgetSize,
+        @Schema(description = "표시 여부", example = "true") Boolean visible,
+        @Schema(description = "강의 ID", example = "1") Long lectureId) {
+    public static WidgetSettingResponse from(WidgetSetting widgetSetting) {
+        return new WidgetSettingResponse(
+                widgetSetting.getId(),
+                widgetSetting.getWidgetType(),
+                widgetSetting.getRowPosition(),
+                widgetSetting.getColPosition(),
+                widgetSetting.getWidgetSize(),
+                widgetSetting.getVisible(),
+                widgetSetting.getLecture().getId());
+    }
+}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/enums/WidgetSize.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/enums/WidgetSize.java
@@ -1,0 +1,16 @@
+package com.seniclass.server.domain.lecture.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum WidgetSize {
+    SMALL(1),
+    LARGE(3),
+    ;
+
+    final int width;
+
+    WidgetSize(int width) {
+        this.width = width;
+    }
+}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/WidgetSettingErrorCode.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/WidgetSettingErrorCode.java
@@ -16,8 +16,6 @@ public enum WidgetSettingErrorCode implements BaseErrorCode {
     WIDGET_SETTING_COUNT_INVALID(HttpStatus.BAD_REQUEST, "위젯 세팅 값은 6개여야 합니다."),
     WIDGET_ID_MISMATCH(HttpStatus.BAD_REQUEST, "요청한 위젯 ID와 강의 정보에 존재하는 위젯 ID 정보가 일치하지 않습니다."),
 
-    // 404 NOT FOUND
-    WIDGET_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 위젯 세팅 값이 6개가 아닙니다."),
 
     // 409 CONFLICT
     ALREADY_EXIST(HttpStatus.CONFLICT, "이미 위젯 세팅 값이 존재합니다."),

--- a/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/WidgetSettingErrorCode.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/WidgetSettingErrorCode.java
@@ -13,6 +13,11 @@ public enum WidgetSettingErrorCode implements BaseErrorCode {
     INVALID_SIZE(HttpStatus.BAD_REQUEST, "위젯의 크기는 1 이상이어야 합니다."),
     INVALID_POSITION(HttpStatus.BAD_REQUEST, "위젯의 위치는 그리드를 벗어날 수 없습니다."),
     INVALID_PLACEMENT(HttpStatus.BAD_REQUEST, "위젯은 겹쳐서 배치할 수 없습니다."),
+    WIDGET_SETTING_COUNT_INVALID(HttpStatus.BAD_REQUEST, "위젯 세팅 값은 6개여야 합니다."),
+    WIDGET_ID_MISMATCH(HttpStatus.BAD_REQUEST, "요청한 위젯 ID와 강의 정보에 존재하는 위젯 ID 정보가 일치하지 않습니다."),
+
+    // 404 NOT FOUND
+    WIDGET_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 위젯 세팅 값이 6개가 아닙니다."),
 
     // 409 CONFLICT
     ALREADY_EXIST(HttpStatus.CONFLICT, "이미 위젯 세팅 값이 존재합니다."),

--- a/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/WidgetSettingErrorCode.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/WidgetSettingErrorCode.java
@@ -16,7 +16,6 @@ public enum WidgetSettingErrorCode implements BaseErrorCode {
     WIDGET_SETTING_COUNT_INVALID(HttpStatus.BAD_REQUEST, "위젯 세팅 값은 6개여야 합니다."),
     WIDGET_ID_MISMATCH(HttpStatus.BAD_REQUEST, "요청한 위젯 ID와 강의 정보에 존재하는 위젯 ID 정보가 일치하지 않습니다."),
 
-
     // 409 CONFLICT
     ALREADY_EXIST(HttpStatus.CONFLICT, "이미 위젯 세팅 값이 존재합니다."),
     ;

--- a/server/src/main/java/com/seniclass/server/domain/lecture/repository/WidgetSettingRepository.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/repository/WidgetSettingRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface WidgetSettingRepository extends JpaRepository<WidgetSetting, Long> {
     boolean existsByLectureId(Long lectureId);
+
+    List<WidgetSetting> findAllByLectureId(Long lectureId);
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/repository/WidgetSettingRepository.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/repository/WidgetSettingRepository.java
@@ -1,11 +1,9 @@
 package com.seniclass.server.domain.lecture.repository;
 
 import com.seniclass.server.domain.lecture.domain.WidgetSetting;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface WidgetSettingRepository extends JpaRepository<WidgetSetting, Long> {

--- a/server/src/main/java/com/seniclass/server/domain/lecture/repository/WidgetSettingRepository.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/repository/WidgetSettingRepository.java
@@ -4,7 +4,10 @@ import com.seniclass.server.domain.lecture.domain.WidgetSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
-public interface WidgetSettingRepository extends JpaRepository<WidgetSetting, Integer> {
+public interface WidgetSettingRepository extends JpaRepository<WidgetSetting, Long> {
     boolean existsByLectureId(Long lectureId);
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingService.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingService.java
@@ -1,16 +1,14 @@
 package com.seniclass.server.domain.lecture.service;
 
 import com.seniclass.server.domain.lecture.domain.Lecture;
-import com.seniclass.server.domain.lecture.domain.WidgetSetting;
 import com.seniclass.server.domain.lecture.dto.request.WidgetSettingUpdateRequest;
 import com.seniclass.server.domain.lecture.dto.response.WidgetSettingResponse;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 
 public interface WidgetSettingService {
 
     void createDefaultWidgetSettings(Lecture lecture);
 
-    List<WidgetSettingResponse> updateWidgetSettings(Long userId, Long lectureId, WidgetSettingUpdateRequest request);
+    List<WidgetSettingResponse> updateWidgetSettings(
+            Long userId, Long lectureId, WidgetSettingUpdateRequest request);
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingService.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingService.java
@@ -1,8 +1,16 @@
 package com.seniclass.server.domain.lecture.service;
 
 import com.seniclass.server.domain.lecture.domain.Lecture;
+import com.seniclass.server.domain.lecture.domain.WidgetSetting;
+import com.seniclass.server.domain.lecture.dto.request.WidgetSettingUpdateRequest;
+import com.seniclass.server.domain.lecture.dto.response.WidgetSettingResponse;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 public interface WidgetSettingService {
 
     void createDefaultWidgetSettings(Lecture lecture);
+
+    List<WidgetSettingResponse> updateWidgetSettings(Long userId, Long lectureId, WidgetSettingUpdateRequest request);
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingServiceImpl.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingServiceImpl.java
@@ -26,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class WidgetSettingServiceImpl implements WidgetSettingService {
 
-    private static final int MAX_ROWS = 3;
+    private static final int MAX_ROWS = 6;
     private static final int MAX_COLS = 4;
     private static final int WIDGETS_COUNT = 6;
 

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingServiceImpl.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingServiceImpl.java
@@ -124,9 +124,9 @@ public class WidgetSettingServiceImpl implements WidgetSettingService {
 
             if (s.row() < 0
                     || s.col() < 0
-                    || s.row() > MAX_ROWS
-                    || s.col() > MAX_COLS
-                    || s.col() + s.widgetSize().getWidth() > MAX_ROWS)
+                    || s.row() >= MAX_ROWS
+                    || s.col() >= MAX_COLS
+                    || s.col() + s.widgetSize().getWidth() > MAX_COLS)
                 throw new CommonException(WidgetSettingErrorCode.INVALID_POSITION);
 
             if (s.visible()) {

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingServiceImpl.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingServiceImpl.java
@@ -3,6 +3,7 @@ package com.seniclass.server.domain.lecture.service;
 import com.seniclass.server.domain.lecture.domain.Lecture;
 import com.seniclass.server.domain.lecture.domain.WidgetSetting;
 import com.seniclass.server.domain.lecture.dto.WidgetSpec;
+import com.seniclass.server.domain.lecture.enums.WidgetSize;
 import com.seniclass.server.domain.lecture.enums.WidgetType;
 import com.seniclass.server.domain.lecture.exception.errorcode.WidgetSettingErrorCode;
 import com.seniclass.server.domain.lecture.repository.WidgetSettingRepository;
@@ -21,12 +22,12 @@ public class WidgetSettingServiceImpl implements WidgetSettingService {
 
     private static final List<WidgetSpec> DEFAULT_SPECS =
             List.of(
-                    new WidgetSpec(WidgetType.TEACHER_INFO, 0, 0, 1, 3, true),
-                    new WidgetSpec(WidgetType.QNA, 0, 3, 1, 1, true),
-                    new WidgetSpec(WidgetType.SUBMISSION, 1, 0, 1, 1, true),
-                    new WidgetSpec(WidgetType.NEXT_LECTURE, 1, 1, 1, 3, true),
-                    new WidgetSpec(WidgetType.STUDENTS_STATUS, 2, 0, 1, 3, true),
-                    new WidgetSpec(WidgetType.REVIEW, 2, 3, 1, 1, true));
+                    new WidgetSpec(WidgetType.TEACHER_INFO, 0, 0, WidgetSize.LARGE, true),
+                    new WidgetSpec(WidgetType.QNA, 0, 3, WidgetSize.SMALL, true),
+                    new WidgetSpec(WidgetType.SUBMISSION, 1, 0, WidgetSize.SMALL, true),
+                    new WidgetSpec(WidgetType.NEXT_LECTURE, 1, 1, WidgetSize.LARGE, true),
+                    new WidgetSpec(WidgetType.STUDENTS_STATUS, 2, 0, WidgetSize.LARGE, true),
+                    new WidgetSpec(WidgetType.REVIEW, 2, 3, WidgetSize.SMALL, true));
 
     private final WidgetSettingRepository widgetSettingRepository;
 
@@ -48,8 +49,7 @@ public class WidgetSettingServiceImpl implements WidgetSettingService {
                                                 s.type(),
                                                 s.row(),
                                                 s.col(),
-                                                s.width(),
-                                                s.height(),
+                                                s.widgetSize(),
                                                 s.visible(),
                                                 lecture))
                         .toList();
@@ -62,17 +62,15 @@ public class WidgetSettingServiceImpl implements WidgetSettingService {
 
         for (WidgetSpec s : specs) {
 
-            if (s.width() <= 0 || s.height() != 1)
-                throw new CommonException(WidgetSettingErrorCode.INVALID_SIZE);
-
             if (s.row() < 0
                     || s.col() < 0
-                    || s.row() + s.height() > MAX_ROWS
-                    || s.col() + s.width() > MAX_COLS)
+                    || s.row() > MAX_ROWS
+                    || s.col() > MAX_COLS
+                    || s.col() + s.widgetSize().getWidth() > MAX_ROWS)
                 throw new CommonException(WidgetSettingErrorCode.INVALID_POSITION);
 
             if (s.visible()) {
-                for (int i = 0; i < s.width(); i++) {
+                for (int i = 0; i < s.widgetSize().getWidth(); i++) {
                     if (grid[s.row()][s.col() + i] == 1) {
                         throw new CommonException(WidgetSettingErrorCode.INVALID_PLACEMENT);
                     }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingServiceImpl.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/WidgetSettingServiceImpl.java
@@ -73,10 +73,8 @@ public class WidgetSettingServiceImpl implements WidgetSettingService {
             Long userId, Long lectureId, WidgetSettingUpdateRequest request) {
 
         // 1) 요청 위젯 type이 6개인지 확인
-        if (request.widgetSpecs().stream()
-                .map(WidgetSpec::type)
-                .collect(Collectors.toSet())
-                .size() != WIDGETS_COUNT) {
+        if (request.widgetSpecs().stream().map(WidgetSpec::type).collect(Collectors.toSet()).size()
+                != WIDGETS_COUNT) {
             throw new CommonException(WidgetSettingErrorCode.WIDGET_ID_MISMATCH);
         }
 


### PR DESCRIPTION
## 🔷 Github Issue ID

[Closes #196]

---
## 📌 작업 내용 및 특이사항
- 프론트 요구사항에 따라서 heigth, width 를 삭제하고 WidgetSize enum으로 변경
- 보이지 않는 위젯(off)의 경우 프론트에서 전송하는 요청 순서에 따라서 업데이트하도록 수정

---
## 📚 참고사항
- 위젯 업데이트 관련 검증 사항은 다음과 같습니다
   -  6개 위젯 설정 정보가 모두 들어왔는지
   - 요청자가 소유한 강의에 대한 위젯 설정 변경 요청이 맞는지
   - 요청에 포함된 위젯 id가 해당 강의가 소유하고 있는 위젯 id 와 일치하는지
   - 설정한 위젯 정보가 올바른 값인지 ( 위치 / 배치 ) 검증
- 순서대로 저장하여 가장 최근에 off 된 위젯을 반환 **LinkedHashMap** 을 활용하여 HTTP 요청에 들어온 순서대로 업데이트가 되도록 했는데, 알맞은 로직인 것 같은지 확인해주시면 좋을 것 같습니다
- swagger 에 **request body** 가 제대로 반영되지 않는 문제가 있습니다. 혹시 빠진 설정이 보이신다면 리뷰 남겨주시면 감사하겠습니다 ㅠㅠ
