### PR TITLE
 [FEATURE] - 시니어 사용자 마이페이지 카드 수정

### DIFF
--- a/client/src/domain/student/component/mypage/MyPageCard.tsx
+++ b/client/src/domain/student/component/mypage/MyPageCard.tsx
@@ -1,22 +1,25 @@
 import RightArrowIcon from "@/assets/icons/default/arrow-right.svg?react";
 
-interface SmallCourseCardProps {
+interface MyPageCardProps {
   subTitle: string;
   title: string;
   courseThumbnail: string;
   onClick?: () => void;
 }
-const SmallCourseCard = ({
+const MyPageCard = ({
   subTitle,
   title,
   courseThumbnail,
   onClick,
-}: SmallCourseCardProps) => {
+}: MyPageCardProps) => {
   return (
     <div
-      className="relative flex h-[28.0956rem] w-[22.625rem] cursor-pointer items-end rounded-[1.25rem] transition-transform duration-300 ease-in-out hover:-translate-y-2.5 hover:shadow-main"
+      className="relative flex h-[28.0956rem] w-[22.625rem] cursor-pointer items-end rounded-[1.25rem] transition-all duration-700 ease-in-out hover:w-[43.9375rem] hover:-translate-y-5 hover:shadow-main"
       style={{
         background: `url(${courseThumbnail})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        backgroundRepeat: "no-repeat",
       }}
       onClick={onClick}
     >
@@ -31,4 +34,4 @@ const SmallCourseCard = ({
   );
 };
 
-export default SmallCourseCard;
+export default MyPageCard;

--- a/client/src/domain/student/page/mypage/MyPage.tsx
+++ b/client/src/domain/student/page/mypage/MyPage.tsx
@@ -5,84 +5,72 @@ import { useNavigate } from "react-router";
 import RightArrowIcon from "@/assets/icons/default/arrow-right.svg?react";
 
 import { fakerKO as faker } from "@faker-js/faker";
-import { useState } from "react";
 
 const MyPage = () => {
   const userName = "쓰리";
   const currentCourseLength = 5;
-  const currentCourseThumbnail = faker.image.urlPicsumPhotos({
-    width: 600,
-    height: 400,
-    grayscale: false,
-    blur: 0,
-  });
-  const currentCourseSubTitle = `수강 중인 강좌 ${currentCourseLength}개`;
-  const currentCourseTitle = "수강 중인 강좌";
-
   const endCourseLength = 3;
-  const endCourseThumbnail = faker.image.urlPicsumPhotos({
-    width: 600,
-    height: 400,
-    grayscale: false,
-    blur: 0,
-  });
-  const endCourseSubTitle = `수강 완료 강좌 ${endCourseLength}개`;
-  const endCourseTitle = "수강 완료 강좌";
-
   const heartCourseLength = 2;
-  const heartCourseThumbnail = faker.image.urlPicsumPhotos({
+
+  const mockThumbnail = faker.image.urlPicsumPhotos({
     width: 600,
     height: 400,
     grayscale: false,
     blur: 0,
   });
-  const heartCourseSubTitle = `찜한 강좌 ${heartCourseLength}개`;
-  const heartCourseTitle = "찜 목록이에요";
-
-  const cardsData = [
-    {
-      courseLength: 5,
-      title: "수강 중인 강좌",
-      subTitle: `수강 중인 강좌 ${currentCourseLength}개`,
-      thumbnail: currentCourseThumbnail,
-    },
-    {
-      courseLength: 5,
-      title: endCourseTitle,
-      subTitle: endCourseSubTitle,
-      thumbnail: endCourseThumbnail,
-      onClick: () => handleEndCourseClick,
-    },
-    {
-      courseLength: 5,
-      title: heartCourseTitle,
-      subTitle: heartCourseSubTitle,
-      thumbnail: heartCourseThumbnail,
-      onClick: () => handleHeartCourseClick,
-    },
-  ];
 
   const navigate = useNavigate();
 
+  const handleCurrentCourseClick = () => {
+    navigate("/student/mypage/current-course");
+  };
+
   const handleEndCourseClick = () => {
-    navigate("/student/mypage/my-course");
+    navigate("/student/mypage/end-course");
   };
 
   const handleHeartCourseClick = () => {
     navigate("/student/mypage/heart");
   };
 
+  const handleMyInfoClick = () => {
+    navigate("/student/mypage/my-info");
+  };
+
+  const cardsData = [
+    {
+      title: "수강 중인 강좌",
+      subTitle: `수강 중인 강좌 ${currentCourseLength}개`,
+      thumbnail: mockThumbnail,
+      onClick: handleCurrentCourseClick,
+    },
+    {
+      title: "수강 완료 강좌",
+      subTitle: `수강 완료 강좌 ${endCourseLength}개`,
+      thumbnail: mockThumbnail,
+      onClick: handleEndCourseClick,
+    },
+    {
+      courseLength: 5,
+      title: "찜 목록이에요",
+      subTitle: `찜한 강좌 ${heartCourseLength}개`,
+      thumbnail: mockThumbnail,
+      onClick: handleHeartCourseClick,
+    },
+  ];
+
   return (
-    <div className="flex h-full w-full flex-col items-center gap-[2.25rem] pt-[4.9375rem] pr-[3.125rem] pb-[9.625rem] pl-[1.875rem]">
+    <div className="flex w-full flex-col items-center gap-[2.25rem] overflow-y-auto pt-[4.9375rem] pr-[3.125rem] pb-[9.625rem] pl-[1.875rem]">
       <p className="typo-title-0 flex h-[7.125rem] w-full text-left whitespace-pre-line">
         {userName}님의 공간이에요 <br /> 어떤 정보를 확인해볼까요?
       </p>
       <div className="flex h-[.0625rem] w-full bg-gray-400" />
 
       <div className="flex h-[42.6875rem] w-full flex-col gap-[43px]">
-        <div className="flex h-[36.9375rem] w-full flex-row items-end gap-[.625rem]">
-          {cardsData.map((card) => (
+        <div className="flex h-[36.9375rem] w-full flex-row items-center justify-center gap-[.625rem]">
+          {cardsData.map((card, index) => (
             <MyPageCard
+              key={index}
               subTitle={card.subTitle}
               title={card.title}
               courseThumbnail={card.thumbnail}
@@ -91,7 +79,10 @@ const MyPage = () => {
           ))}
         </div>
         <div className="flex h-[3.0625rem] w-full justify-end">
-          <button className="flex h-[3.0625rem] w-[14.8125rem] cursor-pointer flex-row items-center justify-between p-[.625rem]">
+          <button
+            className="flex h-[3.0625rem] w-[14.8125rem] cursor-pointer flex-row items-center justify-between p-[.625rem]"
+            onClick={handleMyInfoClick}
+          >
             <span className="typo-body-1">내 정보 수정하기</span>
             <div className="flex h-[1.75rem] w-[1.75rem] items-center justify-center rounded-full bg-black">
               <RightArrowIcon className="w-[.4456rem] text-white" />

--- a/client/src/domain/student/page/mypage/MyPage.tsx
+++ b/client/src/domain/student/page/mypage/MyPage.tsx
@@ -60,14 +60,14 @@ const MyPage = () => {
   ];
 
   return (
-    <div className="flex w-full flex-col items-center gap-[2.25rem] overflow-y-auto pt-[4.9375rem] pr-[3.125rem] pb-[9.625rem] pl-[1.875rem]">
+    <div className="flex w-full flex-col items-center gap-[2.25rem] pt-[4.9375rem] pr-[3.125rem] pb-[9.625rem] pl-[1.875rem]">
       <p className="typo-title-0 flex h-[7.125rem] w-full text-left whitespace-pre-line">
         {userName}님의 공간이에요 <br /> 어떤 정보를 확인해볼까요?
       </p>
-      <div className="flex h-[.0625rem] w-full bg-gray-400" />
+      <hr className="flex h-[.0625rem] w-full text-gray-400" />
 
       <div className="flex h-[42.6875rem] w-full flex-col gap-[43px]">
-        <div className="flex h-[36.9375rem] w-full flex-row items-center justify-center gap-[.625rem]">
+        <div className="flex h-[31.25rem] w-full flex-row items-center justify-center gap-[.625rem]">
           {cardsData.map((card, index) => (
             <MyPageCard
               key={index}

--- a/client/src/domain/student/page/mypage/MyPage.tsx
+++ b/client/src/domain/student/page/mypage/MyPage.tsx
@@ -1,11 +1,11 @@
-import CurrentCourseCard from "@/domain/student/component/mypage/CurrentCourseCard";
-import SmallCourseCard from "@/domain/student/component/mypage/SmallCourseCard";
+import MyPageCard from "@/domain/student/component/mypage/MyPageCard";
 
 import { useNavigate } from "react-router";
 
 import RightArrowIcon from "@/assets/icons/default/arrow-right.svg?react";
 
 import { fakerKO as faker } from "@faker-js/faker";
+import { useState } from "react";
 
 const MyPage = () => {
   const userName = "쓰리";
@@ -16,6 +16,8 @@ const MyPage = () => {
     grayscale: false,
     blur: 0,
   });
+  const currentCourseSubTitle = `수강 중인 강좌 ${currentCourseLength}개`;
+  const currentCourseTitle = "수강 중인 강좌";
 
   const endCourseLength = 3;
   const endCourseThumbnail = faker.image.urlPicsumPhotos({
@@ -37,6 +39,29 @@ const MyPage = () => {
   const heartCourseSubTitle = `찜한 강좌 ${heartCourseLength}개`;
   const heartCourseTitle = "찜 목록이에요";
 
+  const cardsData = [
+    {
+      courseLength: 5,
+      title: "수강 중인 강좌",
+      subTitle: `수강 중인 강좌 ${currentCourseLength}개`,
+      thumbnail: currentCourseThumbnail,
+    },
+    {
+      courseLength: 5,
+      title: endCourseTitle,
+      subTitle: endCourseSubTitle,
+      thumbnail: endCourseThumbnail,
+      onClick: () => handleEndCourseClick,
+    },
+    {
+      courseLength: 5,
+      title: heartCourseTitle,
+      subTitle: heartCourseSubTitle,
+      thumbnail: heartCourseThumbnail,
+      onClick: () => handleHeartCourseClick,
+    },
+  ];
+
   const navigate = useNavigate();
 
   const handleEndCourseClick = () => {
@@ -55,23 +80,15 @@ const MyPage = () => {
       <div className="flex h-[.0625rem] w-full bg-gray-400" />
 
       <div className="flex h-[42.6875rem] w-full flex-col gap-[43px]">
-        <div className="flex h-[36.9375rem] w-full flex-row items-end justify-between">
-          <CurrentCourseCard
-            currentCourseLength={currentCourseLength}
-            currentCourseThumbnail={currentCourseThumbnail}
-          />
-          <SmallCourseCard
-            subTitle={endCourseSubTitle}
-            title={endCourseTitle}
-            courseThumbnail={endCourseThumbnail}
-            onClick={handleEndCourseClick}
-          />
-          <SmallCourseCard
-            subTitle={heartCourseSubTitle}
-            title={heartCourseTitle}
-            courseThumbnail={heartCourseThumbnail}
-            onClick={handleHeartCourseClick}
-          />
+        <div className="flex h-[36.9375rem] w-full flex-row items-end gap-[.625rem]">
+          {cardsData.map((card) => (
+            <MyPageCard
+              subTitle={card.subTitle}
+              title={card.title}
+              courseThumbnail={card.thumbnail}
+              onClick={card.onClick}
+            />
+          ))}
         </div>
         <div className="flex h-[3.0625rem] w-full justify-end">
           <button className="flex h-[3.0625rem] w-[14.8125rem] cursor-pointer flex-row items-center justify-between p-[.625rem]">


### PR DESCRIPTION
## 🔷 Github Issue ID

[Closes #208 ]

---
## 📌 작업 내용 및 특이사항

![mypage](https://github.com/user-attachments/assets/ccb9abd3-3974-491c-8d8e-45ad8de38c05)

- 시니어(학생) 마이페이지 레이아웃 수정했습니다.
- 수강 중, 수강 완료, 찜 목록 모두 같은 카드를 사용하고 Hover하면 카드의 w가 늘어나도록 했습니다.
- 카드의 배경은 수강 중, 수강 완료, 찜 목록 강좌의 대표 이미지 하나가 적용될 예정입니다.

---
## 📚 참고사항

-
