### PR TITLE
[FEATURE] - 신청 전 강좌 상세 화면의 강좌 정보 위젯 API 생성

### DIFF
--- a/server/src/main/java/com/seniclass/server/domain/lecture/controller/LectureController.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/controller/LectureController.java
@@ -65,9 +65,7 @@ public class LectureController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(
-            summary = "강좌 상세 화면의 강좌 정보 사이드바 위젯 (학생)",
-            description = "강좌의 강좌 정보 위젯 데이터를 받습니다.")
+    @Operation(summary = "강좌 상세 화면의 강좌 정보 사이드바 위젯 (학생)", description = "강좌의 강좌 정보 위젯 데이터를 받습니다.")
     @GetMapping("/{lectureId}/side-widget/lecture-info")
     public LectureInfoWidgetResponse getLectureInfoWidget(
             @Parameter(description = "조회할 강좌 id") @PathVariable Long lectureId) {

--- a/server/src/main/java/com/seniclass/server/domain/lecture/controller/LectureController.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/controller/LectureController.java
@@ -66,9 +66,9 @@ public class LectureController {
     }
 
     @Operation(
-            summary = "신청 전 걍좌 상세 화면의 강좌 정보 위젯 (학생)",
-            description = "신청 전 강좌의 강좌 정보 위젯 데이터를 받습니다.")
-    @GetMapping("/{lectureId}/lecture-info-widget")
+            summary = "강좌 상세 화면의 강좌 정보 사이드바 위젯 (학생)",
+            description = "강좌의 강좌 정보 위젯 데이터를 받습니다.")
+    @GetMapping("/{lectureId}/side-widget/lecture-info")
     public LectureInfoWidgetResponse getLectureInfoWidget(
             @Parameter(description = "조회할 강좌 id") @PathVariable Long lectureId) {
         return lectureService.getLectureInfo(lectureId);

--- a/server/src/main/java/com/seniclass/server/domain/lecture/controller/LectureController.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/controller/LectureController.java
@@ -65,7 +65,9 @@ public class LectureController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "신청 전 걍좌 상세 화면의 강좌 정보 위젯 (학생)", description = "신청 전 강좌의 강좌 정보 위젯 데이터를 받습니다.")
+    @Operation(
+            summary = "신청 전 걍좌 상세 화면의 강좌 정보 위젯 (학생)",
+            description = "신청 전 강좌의 강좌 정보 위젯 데이터를 받습니다.")
     @GetMapping("/{lectureId}/lecture-info-widget")
     public LectureInfoWidgetResponse getLectureInfoWidget(
             @Parameter(description = "조회할 강좌 id") @PathVariable Long lectureId) {

--- a/server/src/main/java/com/seniclass/server/domain/lecture/controller/LectureController.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/controller/LectureController.java
@@ -4,6 +4,7 @@ import com.seniclass.server.domain.auth.domain.RequireAuth;
 import com.seniclass.server.domain.auth.enums.UserRole;
 import com.seniclass.server.domain.lecture.dto.request.LectureCreateRequest;
 import com.seniclass.server.domain.lecture.dto.request.LectureUpdateRequest;
+import com.seniclass.server.domain.lecture.dto.response.LectureInfoWidgetResponse;
 import com.seniclass.server.domain.lecture.dto.response.LectureResponse;
 import com.seniclass.server.domain.lecture.service.LectureService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -62,5 +63,12 @@ public class LectureController {
             @Parameter(description = "삭제할 강의 ID") @PathVariable Long lectureId) {
         lectureService.deleteLecture(lectureId);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "신청 전 걍좌 상세 화면의 강좌 정보 위젯 (학생)", description = "신청 전 강좌의 강좌 정보 위젯 데이터를 받습니다.")
+    @GetMapping("/{lectureId}/lecture-info-widget")
+    public LectureInfoWidgetResponse getLectureInfoWidget(
+            @Parameter(description = "조회할 강좌 id") @PathVariable Long lectureId) {
+        return lectureService.getLectureInfo(lectureId);
     }
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/LectureInfoWidgetResponse.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/LectureInfoWidgetResponse.java
@@ -1,0 +1,30 @@
+package com.seniclass.server.domain.lecture.dto.response;
+
+import com.seniclass.server.domain.lecture.domain.Lecture;
+import com.seniclass.server.domain.lecture.enums.Level;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record LectureInfoWidgetResponse(
+        Long lectureId,
+        Integer cohort,
+        List<UploadTimeResponse> uploadTimesList,
+        LocalDate start,
+        LocalDate endDate,
+        Level level,
+        Integer fee
+) {
+    public static LectureInfoWidgetResponse from(
+            Lecture lecture,
+            List<UploadTimeResponse> uploadTimesList) {
+        return new LectureInfoWidgetResponse(
+                lecture.getId(),
+                lecture.getCohort(),
+                uploadTimesList,
+                lecture.getStartDate(),
+                lecture.getEndDate(),
+                lecture.getLevel(),
+                lecture.getFee());
+    }
+}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/LectureInfoWidgetResponse.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/LectureInfoWidgetResponse.java
@@ -2,7 +2,6 @@ package com.seniclass.server.domain.lecture.dto.response;
 
 import com.seniclass.server.domain.lecture.domain.Lecture;
 import com.seniclass.server.domain.lecture.enums.Level;
-
 import java.time.LocalDate;
 import java.util.List;
 
@@ -13,11 +12,9 @@ public record LectureInfoWidgetResponse(
         LocalDate start,
         LocalDate endDate,
         Level level,
-        Integer fee
-) {
+        Integer fee) {
     public static LectureInfoWidgetResponse from(
-            Lecture lecture,
-            List<UploadTimeResponse> uploadTimesList) {
+            Lecture lecture, List<UploadTimeResponse> uploadTimesList) {
         return new LectureInfoWidgetResponse(
                 lecture.getId(),
                 lecture.getCohort(),

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/UploadTimeResponse.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/UploadTimeResponse.java
@@ -1,27 +1,25 @@
 package com.seniclass.server.domain.lecture.dto.response;
 
-import com.seniclass.server.domain.lecture.domain.Chapter;
 import com.seniclass.server.domain.lecture.domain.UploadTime;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.Column;
-
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
 public record UploadTimeResponse(
         @Schema(description = "요일", example = "월") String dayOfWeek,
-        @Schema(description = "시간", example = "HH:mm") LocalTime scheduledAt ) {
+        @Schema(description = "시간", example = "HH:mm") LocalTime scheduledAt) {
     public static UploadTimeResponse from(UploadTime uploadTime) {
         DayOfWeek dayOfWeek = uploadTime.getDayOfWeek();
-        String dayOfWeekString = switch (dayOfWeek) {
-            case MONDAY -> "월";
-            case TUESDAY -> "화";
-            case WEDNESDAY -> "수";
-            case THURSDAY -> "목";
-            case FRIDAY -> "금";
-            case SATURDAY -> "토";
-            case SUNDAY -> "일";
-        };
+        String dayOfWeekString =
+                switch (dayOfWeek) {
+                    case MONDAY -> "월";
+                    case TUESDAY -> "화";
+                    case WEDNESDAY -> "수";
+                    case THURSDAY -> "목";
+                    case FRIDAY -> "금";
+                    case SATURDAY -> "토";
+                    case SUNDAY -> "일";
+                };
         return new UploadTimeResponse(dayOfWeekString, uploadTime.getScheduledAt());
     }
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/UploadTimeResponse.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/dto/response/UploadTimeResponse.java
@@ -1,0 +1,27 @@
+package com.seniclass.server.domain.lecture.dto.response;
+
+import com.seniclass.server.domain.lecture.domain.Chapter;
+import com.seniclass.server.domain.lecture.domain.UploadTime;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record UploadTimeResponse(
+        @Schema(description = "요일", example = "월") String dayOfWeek,
+        @Schema(description = "시간", example = "HH:mm") LocalTime scheduledAt ) {
+    public static UploadTimeResponse from(UploadTime uploadTime) {
+        DayOfWeek dayOfWeek = uploadTime.getDayOfWeek();
+        String dayOfWeekString = switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+        return new UploadTimeResponse(dayOfWeekString, uploadTime.getScheduledAt());
+    }
+}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/UploadTimeErrorCode.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/UploadTimeErrorCode.java
@@ -9,13 +9,12 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UploadTimeErrorCode implements BaseErrorCode {
 
-    //404
+    // 404
     UPLOAD_TIME_NOT_FOUND(HttpStatus.NOT_FOUND, "업로드 시간이 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;
     private final String message;
-
 
     @Override
     public String errorClassName() {

--- a/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/UploadTimeErrorCode.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/exception/errorcode/UploadTimeErrorCode.java
@@ -1,0 +1,24 @@
+package com.seniclass.server.domain.lecture.exception.errorcode;
+
+import com.seniclass.server.global.exception.errorcode.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UploadTimeErrorCode implements BaseErrorCode {
+
+    //404
+    UPLOAD_TIME_NOT_FOUND(HttpStatus.NOT_FOUND, "업로드 시간이 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+
+    @Override
+    public String errorClassName() {
+        return this.name();
+    }
+}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/repository/UploadTimeRepository.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/repository/UploadTimeRepository.java
@@ -1,10 +1,9 @@
 package com.seniclass.server.domain.lecture.repository;
 
 import com.seniclass.server.domain.lecture.domain.UploadTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface UploadTimeRepository extends JpaRepository<UploadTime, Long> {

--- a/server/src/main/java/com/seniclass/server/domain/lecture/repository/UploadTimeRepository.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/repository/UploadTimeRepository.java
@@ -4,5 +4,10 @@ import com.seniclass.server.domain.lecture.domain.UploadTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface UploadTimeRepository extends JpaRepository<UploadTime, Long> {}
+public interface UploadTimeRepository extends JpaRepository<UploadTime, Long> {
+
+    List<UploadTime> findAllByLectureId(Long lectureId);
+}

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/LectureService.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/LectureService.java
@@ -2,6 +2,7 @@ package com.seniclass.server.domain.lecture.service;
 
 import com.seniclass.server.domain.lecture.dto.request.LectureCreateRequest;
 import com.seniclass.server.domain.lecture.dto.request.LectureUpdateRequest;
+import com.seniclass.server.domain.lecture.dto.response.LectureInfoWidgetResponse;
 import com.seniclass.server.domain.lecture.dto.response.LectureResponse;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,4 +16,6 @@ public interface LectureService {
             Long userId, Long lectureId, LectureUpdateRequest request, MultipartFile file);
 
     public void deleteLecture(Long lectureId);
+
+    public LectureInfoWidgetResponse getLectureInfo(Long lectureId);
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/LectureServiceImpl.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/LectureServiceImpl.java
@@ -16,13 +16,12 @@ import com.seniclass.server.global.exception.CommonException;
 import com.seniclass.server.global.exception.errorcode.LectureErrorCode;
 import com.seniclass.server.global.exception.errorcode.UserErrorCode;
 import com.seniclass.server.global.service.FileStorageService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Service
 @Transactional
@@ -143,9 +142,7 @@ public class LectureServiceImpl implements LectureService {
 
         List<UploadTime> uploadTimeList = uploadTimeService.getAllUploadTimesEntity(lecture);
         List<UploadTimeResponse> uploadTimeResponses =
-                uploadTimeList.stream()
-                        .map(UploadTimeResponse::from)
-                        .toList();
+                uploadTimeList.stream().map(UploadTimeResponse::from).toList();
 
         return LectureInfoWidgetResponse.from(lecture, uploadTimeResponses);
     }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/LectureServiceImpl.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/LectureServiceImpl.java
@@ -3,9 +3,12 @@ package com.seniclass.server.domain.lecture.service;
 import com.seniclass.server.domain.category.domain.SubCategory;
 import com.seniclass.server.domain.category.repository.SubCategoryRepository;
 import com.seniclass.server.domain.lecture.domain.Lecture;
+import com.seniclass.server.domain.lecture.domain.UploadTime;
 import com.seniclass.server.domain.lecture.dto.request.LectureCreateRequest;
 import com.seniclass.server.domain.lecture.dto.request.LectureUpdateRequest;
+import com.seniclass.server.domain.lecture.dto.response.LectureInfoWidgetResponse;
 import com.seniclass.server.domain.lecture.dto.response.LectureResponse;
+import com.seniclass.server.domain.lecture.dto.response.UploadTimeResponse;
 import com.seniclass.server.domain.lecture.repository.LectureRepository;
 import com.seniclass.server.domain.teacher.domain.Teacher;
 import com.seniclass.server.domain.teacher.repository.TeacherRepository;
@@ -18,6 +21,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -131,6 +136,18 @@ public class LectureServiceImpl implements LectureService {
 
     public void deleteLecture(Long lectureId) {
         lectureRepository.deleteById(lectureId);
+    }
+
+    public LectureInfoWidgetResponse getLectureInfo(Long lectureId) {
+        Lecture lecture = getLectureEntity(lectureId);
+
+        List<UploadTime> uploadTimeList = uploadTimeService.getAllUploadTimesEntity(lecture);
+        List<UploadTimeResponse> uploadTimeResponses =
+                uploadTimeList.stream()
+                        .map(UploadTimeResponse::from)
+                        .toList();
+
+        return LectureInfoWidgetResponse.from(lecture, uploadTimeResponses);
     }
 
     private Lecture getLectureEntity(Long lectureId) {

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/UploadTimeService.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/UploadTimeService.java
@@ -3,10 +3,14 @@ package com.seniclass.server.domain.lecture.service;
 import com.seniclass.server.domain.lecture.domain.Lecture;
 import com.seniclass.server.domain.lecture.domain.UploadTime;
 import com.seniclass.server.domain.lecture.dto.request.UploadTimeCreateRequest;
+import com.seniclass.server.domain.lecture.exception.errorcode.UploadTimeErrorCode;
 import com.seniclass.server.domain.lecture.repository.UploadTimeRepository;
+import com.seniclass.server.global.exception.CommonException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,5 +23,13 @@ public class UploadTimeService {
         UploadTime uploadTime =
                 UploadTime.create(request.dayOfWeek(), request.scheduledAt(), lecture);
         uploadTimeRepository.save(uploadTime);
+    }
+
+    public List<UploadTime> getAllUploadTimesEntity(Lecture lecture) {
+        List<UploadTime> uplodaTimeList = uploadTimeRepository.findAllByLectureId(lecture.getId());
+        if (uplodaTimeList.isEmpty()) {
+            throw new CommonException(UploadTimeErrorCode.UPLOAD_TIME_NOT_FOUND);
+        }
+        return uplodaTimeList;
     }
 }

--- a/server/src/main/java/com/seniclass/server/domain/lecture/service/UploadTimeService.java
+++ b/server/src/main/java/com/seniclass/server/domain/lecture/service/UploadTimeService.java
@@ -6,11 +6,10 @@ import com.seniclass.server.domain.lecture.dto.request.UploadTimeCreateRequest;
 import com.seniclass.server.domain.lecture.exception.errorcode.UploadTimeErrorCode;
 import com.seniclass.server.domain.lecture.repository.UploadTimeRepository;
 import com.seniclass.server.global.exception.CommonException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 🔷 Github Issue ID

[Closes #224]

---
## 📌 작업 내용 및 특이사항
- 아래 화면에 해당하는 API 생성
<img width="271" height="486" alt="스크린샷 2025-08-12 18 01 34" src="https://github.com/user-attachments/assets/02e0a174-7d3e-417e-b0d1-d764533108c2" />

---
## 📚 참고사항
- Service 가 엔티티 자체를 반환하지 않도록 하고 싶었는데, Repository 와 Service 를 모두 의존 받아 사용하는게 마음에 들지 않아서 Service 에서 엔티티를 반환할 수 있도록 허용하고 컨트롤러 단에서는 엔티티를 반환하는 메서드는 사용하지 않도록 구현했습니다.
의식적으로는 가능할 것 같은데 코드 레벨에서 제한하는 방법이 없을까 고민이 되네용
