### PR TITLE
 [FEATURE] - 강좌 상세 카드 퍼블리싱 (가격 표시)

### DIFF
--- a/client/src/shared/components/course/CourseDetailCard.tsx
+++ b/client/src/shared/components/course/CourseDetailCard.tsx
@@ -1,0 +1,110 @@
+import Button from "@/shared/components/Button";
+import { useState } from "react";
+
+import HeartIcon from "@/assets/icons/default/heart.svg?react";
+import CircleButton from "@/shared/components/CircleButton";
+import YellowStartIcon from "@/assets/icons/default/yellow-star.svg?react";
+
+interface CourseDetailCardProps {
+  imageUrl?: string;
+  teacherName?: string;
+  title?: string;
+  days?: string[];
+  startTime?: string;
+  endTime?: string;
+  rating?: number;
+  reviews?: number;
+  price?: number;
+  defaultFavorite?: boolean;
+}
+
+const CourseDetailCard = ({
+  imageUrl = "https://cdn.pixabay.com/photo/2025/04/25/12/13/nature-9558835_1280.jpg",
+  teacherName = "홍길동",
+  title = "프론트엔드 개발자 양성 과정",
+  days = ["월", "수", "금"],
+  startTime = "10:00",
+  endTime = "12:00",
+  rating = 4.5,
+  reviews = 120,
+  price = 2000000,
+  defaultFavorite = false,
+}: CourseDetailCardProps) => {
+  const [favorite, setFavorite] = useState(defaultFavorite);
+
+  const toggleFavorite = () => {
+    setFavorite((prev) => !prev);
+    // 여기에 즐겨찾기 상태 변경 로직 추가 (예: API 호출)
+  };
+
+  return (
+    <div className="group relative flex h-[32.3125rem] w-[26.9375rem] flex-col gap-[.9375rem] overflow-clip rounded-[1.25rem] bg-white px-[1.375rem] py-[1.6563rem] transition-all duration-300 hover:-translate-y-[1.6875rem] hover:shadow-main">
+      {/* 호버 시 카드 위(z)에 뜨는 버튼 */}
+      <div className="absolute top-[19.0625rem] right-[2.3125rem] z-20 translate-y-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
+        <Button
+          variant={"outline"}
+          className="typo-label-1 h-[3.3125rem] w-[6.25rem] cursor-pointer"
+        >
+          상세 보기
+        </Button>
+      </div>
+
+      {/* 이미지 영역 */}
+      <div className="relative">
+        <img
+          src={imageUrl}
+          alt={title}
+          className="h-[19.75rem] w-full rounded-[1.25rem] object-cover"
+        />
+
+        {/* 하트 버튼 (즐겨찾기) */}
+        <div className="absolute top-[1.4375rem] right-[1.4375rem] z-10">
+          <CircleButton
+            variant="ghost"
+            onClick={toggleFavorite}
+            icon={
+              favorite ? (
+                <HeartIcon className="w-[2.375rem] text-main-500" /> // 채워진 하트 아이콘
+              ) : (
+                <HeartIcon className="w-[2.375rem] text-white/50" />
+              )
+            }
+          />
+        </div>
+      </div>
+
+      {/* 내용 영역 */}
+      <div className="flex h-full flex-col gap-[.5625rem]">
+        <span className="typo-label-2 whitespace-nowrap text-gray-500">
+          {teacherName}
+        </span>
+        <span className="typo-title-3 truncate whitespace-nowrap">{title}</span>
+        <div className="flex items-center gap-[.9375rem]">
+          <span className="typo-body-6">{days.join(" ")}</span>
+          <span className="typo-body-6">
+            {startTime} ~ {endTime}
+          </span>
+        </div>
+
+        {/* 별점 */}
+        <div className="flex items-end justify-between">
+          <div className="typo-label-2 flex items-center gap-1">
+            <YellowStartIcon className="h-[1.125rem] w-[1.125rem] text-yellow-400" />
+            <span>{rating.toFixed(1)}</span>
+            <span className="text-gray-500">({reviews})</span>
+          </div>
+
+          {/* 가격 */}
+          <div className="flex items-end gap-2">
+            <span className="typo-title-3 text-right">
+              {price.toLocaleString()}
+            </span>
+            <span className="typo-body-5">/ 시간</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CourseDetailCard;

--- a/client/src/shared/components/course/CourseDetailCard.tsx
+++ b/client/src/shared/components/course/CourseDetailCard.tsx
@@ -42,7 +42,7 @@ const CourseDetailCard = ({
       {/* 호버 시 카드 위(z)에 뜨는 버튼 */}
       <div className="absolute top-[19.0625rem] right-[2.3125rem] z-20 translate-y-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
         <Button
-          variant={"outline"}
+          variant="outline"
           className="typo-label-1 h-[3.3125rem] w-[6.25rem] cursor-pointer"
         >
           상세 보기

--- a/client/src/shared/components/course/CourseDetailCard.tsx
+++ b/client/src/shared/components/course/CourseDetailCard.tsx
@@ -96,10 +96,16 @@ const CourseDetailCard = ({
 
           {/* 가격 */}
           <div className="flex items-end gap-2">
-            <span className="typo-title-3 text-right">
-              {price.toLocaleString()}
-            </span>
-            <span className="typo-body-5">/ 시간</span>
+            {price === 0 ? (
+              <span className="typo-title-3 text-right">무료</span>
+            ) : (
+              <>
+                <span className="typo-title-3 text-right">
+                  {price.toLocaleString()}
+                </span>
+                <span className="typo-body-5">/ 시간</span>
+              </>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🔷 Github Issue ID

[Closes #214 ]

---
## 📌 작업 내용 및 특이사항
![detail cards](https://github.com/user-attachments/assets/ac98cc4d-cb55-4eb5-913b-88fa3897cd5b)

- 금액이 표시된 강좌 상세 카드 퍼블리싱했습니다.
- 해당 카드는 찜 목록, 강좌 검색 결과, 추천강좌 확인, 강사 홈페이지에서 사용될 예정입니다.

---
## 📚 참고사항

- 버튼 부분이 피그마와 살짝 다릅니다. button variable 수정하는 것보단 그냥 텍스트만 들어가도록 하는 것이 나을 것 같아 임의로 수정했습니다...ㅎㅎ
- 강사 홈페이지의 경우, 피그마에 있는 카드와 완전히 다른데 이전에 강사 홈페이지에 있는 카드에서 더 많은 정보를 보여주는 것이 좋다고 하셔서 이 카드를 사용하려고 합니다! 어떠신가요?

