### PR TITLE
 [FEATURE] - 수강 중 강좌 페이지 퍼블리싱

### DIFF
--- a/client/src/domain/student/component/course/CourseProgressCard.tsx
+++ b/client/src/domain/student/component/course/CourseProgressCard.tsx
@@ -10,6 +10,7 @@ interface CourseProgressCardProps {
   endTime?: string;
   currentVideo?: number;
   maxVideo?: number;
+  onClick?: () => void;
 }
 
 const CourseProgressCard = ({
@@ -21,6 +22,7 @@ const CourseProgressCard = ({
   endTime = "12:00",
   currentVideo = 3,
   maxVideo = 10,
+  onClick = () => {},
 }: CourseProgressCardProps) => {
   return (
     <div className="group relative flex h-[32.3125rem] w-[26.9375rem] flex-col gap-[.9375rem] overflow-clip rounded-[1.25rem] bg-white px-[1.375rem] py-[1.6563rem] transition-all duration-300 hover:-translate-y-[1.6875rem] hover:shadow-main">
@@ -29,6 +31,7 @@ const CourseProgressCard = ({
         <Button
           variant="outline"
           className="typo-label-1 h-[3.3125rem] w-[6.25rem] cursor-pointer"
+          onClick={onClick}
         >
           상세 보기
         </Button>

--- a/client/src/domain/student/page/index.tsx
+++ b/client/src/domain/student/page/index.tsx
@@ -4,5 +4,5 @@ export { default as SearchResultPage } from "@/domain/student/page/course/Search
 
 export { default as MyPage } from "@/domain/student/page/mypage/MyPage";
 export { default as HeartPage } from "@/domain/student/page/mypage/HeartPage";
-export { default as MyCoursePage } from "@/domain/student/page/mypage/MyCoursePage";
+export { default as CurrentCoursePage } from "@/domain/student/page/mypage/CurrentCoursePage";
 export { default as CourseDetailDashboardPage } from "@/domain/student/page/course/CourseDetailDashboardPage";

--- a/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
+++ b/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
@@ -2,7 +2,7 @@ import CourseProgressCard from "@/domain/student/component/course/CourseProgress
 import InfoChip from "@/shared/components/InfoChip";
 import { fakerKO as faker } from "@faker-js/faker";
 
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 const CurrentCoursePage = () => {
   const navigate = useNavigate();

--- a/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
+++ b/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 const CurrentCoursePage = () => {
   const navigate = useNavigate();
   const studentName = "홍길동";
-  let currentCourseLength = 30;
+  const currentCourseLength: number = 30;
 
   const infoChipText =
     currentCourseLength === 0

--- a/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
+++ b/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 const CurrentCoursePage = () => {
   const navigate = useNavigate();
   const studentName = "홍길동";
-  let currentCourseLength = 3;
+  let currentCourseLength = 30;
 
   const infoChipText =
     currentCourseLength === 0
@@ -47,7 +47,9 @@ const CurrentCoursePage = () => {
     };
   };
 
-  const course = faker.helpers.multiple(createCourseData, { count: 30 });
+  const course = faker.helpers.multiple(createCourseData, {
+    count: currentCourseLength,
+  });
   const handleCardClick = (id: number) => {
     navigate(`/student/course/${id}/dashboard`);
   };

--- a/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
+++ b/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
@@ -1,8 +1,26 @@
+import InfoChip from "@/shared/components/InfoChip";
+
 const CurrentCoursePage = () => {
+  const studentName = "홍길동";
+  let currentCourseLength = 3;
+
+  const infoChipText =
+    currentCourseLength === 0
+      ? `${studentName}님은 아직 수강 중인 강의가 없어요`
+      : `${studentName}님은 ${currentCourseLength}개의 강좌를 수강중이시네요!`;
+
   return (
-    <div>
-      <h1>My Course Page</h1>
-      <p>This is the My Course Page content.</p>
+    <div className="flex h-full w-full flex-col items-start gap-[1.25rem] overflow-auto pr-[3.0625rem] pb-[4.625rem] pl-[2.8125rem]">
+      <div className="sticky top-0 flex w-full flex-col items-start gap-[1.25rem] bg-gradient-to-b from-bg from-85% to-transparent to-100% pt-[4.625rem] pb-[1.875rem]">
+        <div className="flex w-full flex-row items-center gap-[2.25rem]">
+          <span className="typo-title-0">현재 수강 중인 강좌</span>
+          <InfoChip text={infoChipText} />
+        </div>
+        <span className="typo-title-6 text-gray-600">
+          총 {currentCourseLength}건
+        </span>
+      </div>
+      <div className="grid grid-cols-3 gap-[1.25rem]"></div>
     </div>
   );
 };

--- a/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
+++ b/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
@@ -1,6 +1,11 @@
+import CourseProgressCard from "@/domain/student/component/course/CourseProgressCard";
 import InfoChip from "@/shared/components/InfoChip";
+import { fakerKO as faker } from "@faker-js/faker";
+
+import { useNavigate } from "react-router-dom";
 
 const CurrentCoursePage = () => {
+  const navigate = useNavigate();
   const studentName = "홍길동";
   let currentCourseLength = 3;
 
@@ -9,9 +14,47 @@ const CurrentCoursePage = () => {
       ? `${studentName}님은 아직 수강 중인 강의가 없어요`
       : `${studentName}님은 ${currentCourseLength}개의 강좌를 수강중이시네요!`;
 
+  const createCourseData = () => {
+    return {
+      courseId: faker.number.int({ min: 1, max: 100 }),
+      imageUrl:
+        "https://cdn.pixabay.com/photo/2025/04/25/12/13/nature-9558835_1280.jpg",
+      teacherName: faker.person.fullName(),
+      title: faker.helpers.arrayElement([
+        "프론트엔드 개발자 양성 과정",
+        "백엔드 개발자 양성 과정",
+        "데이터베이스 관리 과정",
+        "웹 디자인 기초 과정",
+        "모바일 앱 개발 과정",
+      ]),
+      days: faker.helpers.arrayElements(["월", "화", "수", "목", "금"]),
+      startTime: faker.helpers.arrayElement([
+        "09:00",
+        "10:00",
+        "11:00",
+        "13:00",
+        "14:00",
+      ]),
+      endTime: faker.helpers.arrayElement([
+        "11:00",
+        "12:00",
+        "13:00",
+        "15:00",
+        "16:00",
+      ]),
+      currentVideo: faker.number.int({ min: 1, max: 10 }),
+      maxVideo: faker.number.int({ min: 10, max: 20 }),
+    };
+  };
+
+  const course = faker.helpers.multiple(createCourseData, { count: 30 });
+  const handleCardClick = (id: number) => {
+    navigate(`/student/course/${id}/dashboard`);
+  };
+
   return (
     <div className="flex h-full w-full flex-col items-start gap-[1.25rem] overflow-auto pr-[3.0625rem] pb-[4.625rem] pl-[2.8125rem]">
-      <div className="sticky top-0 flex w-full flex-col items-start gap-[1.25rem] bg-gradient-to-b from-bg from-85% to-transparent to-100% pt-[4.625rem] pb-[1.875rem]">
+      <div className="sticky top-0 z-30 flex w-full flex-col items-start gap-[1.25rem] bg-gradient-to-b from-bg from-85% to-transparent to-100% pt-[4.625rem] pb-[1.875rem]">
         <div className="flex w-full flex-row items-center gap-[2.25rem]">
           <span className="typo-title-0">현재 수강 중인 강좌</span>
           <InfoChip text={infoChipText} />
@@ -20,7 +63,22 @@ const CurrentCoursePage = () => {
           총 {currentCourseLength}건
         </span>
       </div>
-      <div className="grid grid-cols-3 gap-[1.25rem]"></div>
+      <div className="grid grid-cols-3 gap-[2.125rem]">
+        {course.map((course) => (
+          <CourseProgressCard
+            key={course.courseId}
+            imageUrl={course.imageUrl}
+            teacherName={course.teacherName}
+            title={course.title}
+            days={course.days}
+            startTime={course.startTime}
+            endTime={course.endTime}
+            currentVideo={course.currentVideo}
+            maxVideo={course.maxVideo}
+            onClick={() => handleCardClick(course.courseId)}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
+++ b/client/src/domain/student/page/mypage/CurrentCoursePage.tsx
@@ -1,4 +1,4 @@
-const MyCoursePage = () => {
+const CurrentCoursePage = () => {
   return (
     <div>
       <h1>My Course Page</h1>
@@ -7,4 +7,4 @@ const MyCoursePage = () => {
   );
 };
 
-export default MyCoursePage;
+export default CurrentCoursePage;

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -39,6 +39,7 @@ export const router = createBrowserRouter([
   {
     path: "/student/course/:courseId",
     Component: StickyLogoLayout,
+
     children: [
       {
         path: "dashboard",

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -30,7 +30,7 @@ export const router = createBrowserRouter([
       { path: "home", Component: S.HomePage },
       { path: "mypage", Component: S.MyPage },
       { path: "mypage/heart", Component: S.HeartPage },
-      { path: "mypage/my-course", Component: S.CurrentCoursePage },
+      { path: "mypage/current-course", Component: S.CurrentCoursePage },
       { path: "course/search", Component: S.SearchResultPage },
     ],
   },

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -30,7 +30,7 @@ export const router = createBrowserRouter([
       { path: "home", Component: S.HomePage },
       { path: "mypage", Component: S.MyPage },
       { path: "mypage/heart", Component: S.HeartPage },
-      { path: "mypage/my-course", Component: S.MyCoursePage },
+      { path: "mypage/my-course", Component: S.CurrentCoursePage },
       { path: "course/search", Component: S.SearchResultPage },
     ],
   },

--- a/client/src/shared/components/InfoChip.tsx
+++ b/client/src/shared/components/InfoChip.tsx
@@ -1,0 +1,15 @@
+interface InfoChipProps {
+  text: string;
+}
+const InfoChip = ({ text }: InfoChipProps) => {
+  return (
+    <div className="flex h-fit w-fit items-center gap-2.5 rounded-full bg-gradient-to-r from-[#A0EACF] to-[#7DA7F9] px-2 py-2">
+      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-[#0066FF]">
+        !
+      </span>
+      <span className="typo-label-3 text-white">{text}</span>
+    </div>
+  );
+};
+
+export default InfoChip;


### PR DESCRIPTION
## 🔷 Github Issue ID

[Closes #218 ]

---
## 📌 작업 내용 및 특이사항
![current course page](https://github.com/user-attachments/assets/36bafe72-9933-451b-9254-6d6e928439e5)
- 수강 중인 강좌 페이지 퍼블리싱 완료했습니다.
- 피그마 상으로는 수강 중/수강 완료 강좌 페이지를 탭 바로 이동할 수 있지만, 마이페이지에서 이미 수강 중/ 수강 완료 강좌에 대해 분기처리가 되어있어 페이지를 따로 분리하는게 좋다고 생각했습니다.
- 상세 보기 버튼을 누르면 해당 강좌의 dashboard 페이지로 라우팅되도록 연결해두었습니다.

---
## 📚 참고사항
<img width="269" height="75" alt="image" src="https://github.com/user-attachments/assets/fb70deef-9c61-4608-9fe8-ad29b912e6f9" />

- 강좌 생성 페이지에 쓰인 상단 그라데이션 칩이 다른 페이지에서도 반복적으로 사용되어 InfoChip 공통 컴포넌트( f3d85ba6f8b1a190c77b588065263bd38e2fae54)로 제작하였습니다! 추후 리팩토링 시 InfoChip 컴포넌트로 사용해주시면 좋을 것 같아요
- card를 여러 개 렌더링 하는 부분을 페이지에 둘지, card 렌더링 부분을 다른 컴포넌트로 뺄 지 고민입니다! 관련해서 의견 주시면 api 연결 작업 시 반영해 보겠습니다~
