### PR TITLE
[FEATURE] - 강사의 내 강좌 목록 페이지(홈) 퍼블리싱

### DIFF
--- a/client/src/domain/instructor/component/course/CourseCardContainer.tsx
+++ b/client/src/domain/instructor/component/course/CourseCardContainer.tsx
@@ -1,0 +1,67 @@
+import CourseDetailCard from "@/shared/components/course/CourseDetailCard";
+import { useNavigate } from "react-router";
+
+interface CourseDetailCardProps {
+  courseId: number;
+  imageUrl?: string;
+  teacherName?: string;
+  title?: string;
+  days?: string[];
+  startTime?: string;
+  endTime?: string;
+  rating?: number;
+  reviews?: number;
+  price?: number;
+  heartButtonInvisible?: boolean;
+  defaultFavorite?: boolean;
+}
+
+interface CourseCardContainerProps {
+  cardItems?: CourseDetailCardProps[];
+}
+
+const CourseCardContainer = ({ cardItems }: CourseCardContainerProps) => {
+  const navigate = useNavigate();
+
+  const handleCardClick = (courseId: number) => {
+    navigate(`/instructor/course/${courseId}/dashboard`);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-[2.4375rem]">
+      <span className="typo-title-4 pt-[1.25rem] text-gray-600">
+        총 {cardItems?.length}건
+      </span>
+
+      {cardItems && cardItems.length > 0 ? (
+        <div className="flex w-full">
+          <div className="grid grid-cols-3 gap-[2.125rem]">
+            {cardItems.map((item) => (
+              <CourseDetailCard
+                key={item.courseId}
+                imageUrl={item.imageUrl}
+                teacherName={item.teacherName}
+                title={item.title}
+                days={item.days}
+                startTime={item.startTime}
+                endTime={item.endTime}
+                rating={item.rating}
+                reviews={item.reviews}
+                price={item.price}
+                heartButtonInvisible={item.heartButtonInvisible}
+                defaultFavorite={item.defaultFavorite}
+                onClick={() => handleCardClick(item.courseId)}
+              />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="flex h-[31.25rem] items-center justify-center text-gray-500">
+          표시할 강좌가 없습니다.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CourseCardContainer;

--- a/client/src/domain/instructor/page/HomePage.tsx
+++ b/client/src/domain/instructor/page/HomePage.tsx
@@ -1,7 +1,74 @@
+import CourseCardContainer from "@/domain/instructor/component/course/CourseCardContainer";
+import Button from "@/shared/components/Button";
+import CourseTab from "@/shared/components/course/CourseTab";
+import { fakerKO as faker } from "@faker-js/faker";
+import { useNavigate } from "react-router";
+
 const HomePage = () => {
+  const navigate = useNavigate();
+  const instructorName = "하하하";
+  const createCourseData = () => {
+    return {
+      courseId: faker.number.int({ min: 1, max: 100 }),
+      imageUrl:
+        "https://cdn.pixabay.com/photo/2025/04/25/12/13/nature-9558835_1280.jpg",
+      teacherName: faker.person.fullName(),
+      title: faker.helpers.arrayElement([
+        "프론트엔드 개발자 양성 과정",
+        "백엔드 개발자 양성 과정",
+        "데이터베이스 관리 과정",
+        "웹 디자인 기초 과정",
+        "모바일 앱 개발 과정",
+      ]),
+      days: faker.helpers.arrayElements(["월", "화", "수", "목", "금"]),
+      startTime: faker.helpers.arrayElement([
+        "09:00",
+        "10:00",
+        "11:00",
+        "13:00",
+        "14:00",
+      ]),
+      endTime: faker.helpers.arrayElement([
+        "11:00",
+        "12:00",
+        "13:00",
+        "15:00",
+        "16:00",
+      ]),
+      rating: faker.number.float({ min: 1, max: 5 }),
+      reviews: faker.number.int({ min: 0, max: 500 }),
+      price: faker.number.int({ min: 100000, max: 5000000 }),
+      heartButtonInvisible: true,
+    };
+  };
+
+  const currentCourse = faker.helpers.multiple(createCourseData, {
+    count: 30,
+  });
+
+  const tabItems = [
+    {
+      label: "진행 중인 강좌",
+      content: <CourseCardContainer cardItems={currentCourse} />,
+    },
+    { label: "종료된 강좌", content: <CourseCardContainer cardItems={[]} /> },
+  ];
+
+  const handleNewCourseClick = () => {
+    navigate("/instructor/course/create");
+  };
+
   return (
-    <div>
-      <h1>Instructor Home Page</h1>
+    <div className="flex w-full flex-col gap-[1.25rem] pt-[4.9375rem] pr-[3.9375rem]">
+      <div className="flex w-full items-center justify-between">
+      <h1 className="typo-title-0">{instructorName} 강사님, 안녕하세요</h1>
+      </div>
+      <div className="relative">
+        <div className="absolute top-0 right-20 z-300">
+          <Button variant="outline" onClick={handleNewCourseClick}>신규 강좌 등록하기</Button>
+        </div>
+        <CourseTab tabItems={tabItems} />
+      </div>
     </div>
   );
 };

--- a/client/src/domain/instructor/page/HomePage.tsx
+++ b/client/src/domain/instructor/page/HomePage.tsx
@@ -61,11 +61,13 @@ const HomePage = () => {
   return (
     <div className="flex w-full flex-col gap-[1.25rem] pt-[4.9375rem] pr-[3.9375rem]">
       <div className="flex w-full items-center justify-between">
-      <h1 className="typo-title-0">{instructorName} 강사님, 안녕하세요</h1>
+        <h1 className="typo-title-0">{instructorName} 강사님, 안녕하세요</h1>
       </div>
       <div className="relative">
         <div className="absolute top-0 right-20 z-300">
-          <Button variant="outline" onClick={handleNewCourseClick}>신규 강좌 등록하기</Button>
+          <Button variant="outline" onClick={handleNewCourseClick}>
+            신규 강좌 등록하기
+          </Button>
         </div>
         <CourseTab tabItems={tabItems} />
       </div>

--- a/client/src/domain/student/page/mypage/HeartPage.tsx
+++ b/client/src/domain/student/page/mypage/HeartPage.tsx
@@ -1,10 +1,80 @@
-const HeartPage = () => {
+import CourseDetailCard from "@/shared/components/course/CourseDetailCard";
+import { fakerKO as faker } from "@faker-js/faker";
+
+import { useNavigate } from "react-router";
+
+const EndCoursePage = () => {
+  const navigate = useNavigate();
+  const studentName = "홍길동";
+  const currentCourseLength: number = 30;
+
+  const createCourseData = () => {
+    return {
+      courseId: faker.number.int({ min: 1, max: 100 }),
+      imageUrl:
+        "https://cdn.pixabay.com/photo/2025/04/25/12/13/nature-9558835_1280.jpg",
+      teacherName: faker.person.fullName(),
+      title: faker.helpers.arrayElement([
+        "프론트엔드 개발자 양성 과정",
+        "백엔드 개발자 양성 과정",
+        "데이터베이스 관리 과정",
+        "웹 디자인 기초 과정",
+        "모바일 앱 개발 과정",
+      ]),
+      days: faker.helpers.arrayElements(["월", "화", "수", "목", "금"]),
+      startTime: faker.helpers.arrayElement([
+        "09:00",
+        "10:00",
+        "11:00",
+        "13:00",
+        "14:00",
+      ]),
+      endTime: faker.helpers.arrayElement([
+        "11:00",
+        "12:00",
+        "13:00",
+        "15:00",
+        "16:00",
+      ]),
+      currentVideo: faker.number.int({ min: 1, max: 10 }),
+      maxVideo: faker.number.int({ min: 10, max: 20 }),
+    };
+  };
+
+  const course = faker.helpers.multiple(createCourseData, {
+    count: currentCourseLength,
+  });
+  const handleCardClick = (id: number) => {
+    navigate(`/student/course/${id}/dashboard`);
+  };
+
   return (
-    <div>
-      <h1>HeartPage</h1>
-      <p>This is the HeartPage content.</p>
+    <div className="flex h-full w-full flex-col items-start gap-[1.25rem] overflow-auto pr-[3.0625rem] pb-[4.625rem] pl-[2.8125rem]">
+      <div className="sticky top-0 z-30 flex w-full flex-col items-start gap-[1.25rem] bg-gradient-to-b from-bg from-85% to-transparent to-100% pt-[4.625rem] pb-[1.875rem]">
+        <div className="flex w-full flex-row items-center gap-[2.25rem]">
+          <span className="typo-title-0">{studentName}님의 찜 목록이에요</span>
+        </div>
+        <span className="typo-title-6 text-gray-600">
+          총 {currentCourseLength}개
+        </span>
+      </div>
+      <div className="grid grid-cols-3 gap-[2.125rem]">
+        {course.map((course) => (
+          <CourseDetailCard
+            key={course.courseId}
+            imageUrl={course.imageUrl}
+            teacherName={course.teacherName}
+            title={course.title}
+            days={course.days}
+            startTime={course.startTime}
+            endTime={course.endTime}
+            defaultFavorite={true}
+            onClick={() => handleCardClick(course.courseId)}
+          />
+        ))}
+      </div>
     </div>
   );
 };
 
-export default HeartPage;
+export default EndCoursePage;

--- a/client/src/shared/components/course/CourseDetailCard.tsx
+++ b/client/src/shared/components/course/CourseDetailCard.tsx
@@ -15,6 +15,7 @@ interface CourseDetailCardProps {
   rating?: number;
   reviews?: number;
   price?: number;
+  heartButtonInvisible?: boolean;
   defaultFavorite?: boolean;
 }
 
@@ -28,6 +29,7 @@ const CourseDetailCard = ({
   rating = 4.5,
   reviews = 120,
   price = 2000000,
+  heartButtonInvisible = false,
   defaultFavorite = false,
 }: CourseDetailCardProps) => {
   const [favorite, setFavorite] = useState(defaultFavorite);
@@ -58,19 +60,21 @@ const CourseDetailCard = ({
         />
 
         {/* 하트 버튼 (즐겨찾기) */}
-        <div className="absolute top-[1.4375rem] right-[1.4375rem] z-10">
-          <CircleButton
-            variant="ghost"
-            onClick={toggleFavorite}
-            icon={
-              favorite ? (
-                <HeartIcon className="w-[2.375rem] text-main-500" /> // 채워진 하트 아이콘
-              ) : (
-                <HeartIcon className="w-[2.375rem] text-white/50" />
-              )
-            }
-          />
-        </div>
+        {!heartButtonInvisible && (
+          <div className="absolute top-[1.4375rem] right-[1.4375rem] z-10">
+            <CircleButton
+              variant="ghost"
+              onClick={toggleFavorite}
+              icon={
+                favorite ? (
+                  <HeartIcon className="w-[2.375rem] text-main-500" /> // 채워진 하트 아이콘
+                ) : (
+                  <HeartIcon className="w-[2.375rem] text-white/50" />
+                )
+              }
+            />
+          </div>
+        )}
       </div>
 
       {/* 내용 영역 */}

--- a/client/src/shared/components/course/CourseDetailCard.tsx
+++ b/client/src/shared/components/course/CourseDetailCard.tsx
@@ -17,6 +17,7 @@ interface CourseDetailCardProps {
   price?: number;
   heartButtonInvisible?: boolean;
   defaultFavorite?: boolean;
+  onClick?: () => void;
 }
 
 const CourseDetailCard = ({
@@ -31,6 +32,7 @@ const CourseDetailCard = ({
   price = 2000000,
   heartButtonInvisible = false,
   defaultFavorite = false,
+  onClick = () => {},
 }: CourseDetailCardProps) => {
   const [favorite, setFavorite] = useState(defaultFavorite);
 
@@ -46,6 +48,7 @@ const CourseDetailCard = ({
         <Button
           variant="outline"
           className="typo-label-1 h-[3.3125rem] w-[6.25rem] cursor-pointer"
+          onClick={onClick}
         >
           상세 보기
         </Button>

--- a/client/src/shared/components/course/CourseTab.tsx
+++ b/client/src/shared/components/course/CourseTab.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+
+interface TabItem {
+  label: string;
+  content: React.ReactNode;
+}
+interface CourseTabProps {
+  tabItems?: TabItem[];
+}
+
+const CourseTab = ({
+  tabItems = [
+    {
+      label: "진행 중인 강좌",
+      content: <div>진행 중인 강좌 콘텐츠</div>,
+    },
+    { label: "종료된 강좌", content: <div>종료된 강좌 콘텐츠</div> },
+  ],
+}: CourseTabProps) => {
+  const [activeTab, setActiveTab] = useState(0);
+
+  const handleTabClick = (index: number) => {
+    setActiveTab(index);
+  };
+
+  return (
+    <div className="flex w-full flex-col">
+      {/* 탭 바 영역 */}
+      <nav className="sticky top-0 z-100 w-full bg-bg py-[1rem]">
+        <div
+          role="tablist"
+          className="typo-body-1 flex h-[2.8125rem] items-end gap-8"
+        >
+          {tabItems.map(({ label }, index) => (
+            <button
+              className={`flex w-[16rem] cursor-pointer justify-center border-b-3 pb-[.4375rem] hover:text-black focus:outline-none ${activeTab === index ? "border-main-400 text-black" : "border-transparent text-gray-600"}`}
+              key={index}
+              onClick={() => handleTabClick(index)}
+            >
+              <span className="pb-[0.3rem]">{label}</span>
+            </button>
+          ))}
+        </div>
+      </nav>
+      {/* 콘텐츠 영역 */}
+      <div>{tabItems[activeTab]?.content}</div>
+    </div>
+  );
+};
+
+export default CourseTab;

--- a/client/src/shared/layout/InstructorLayout.tsx
+++ b/client/src/shared/layout/InstructorLayout.tsx
@@ -4,7 +4,7 @@ import { Outlet } from "react-router";
 
 const InstructorLayout = () => {
   return (
-    <div className="flex h-screen flex-row gap-3">
+    <div className="flex flex-row gap-3">
       <InstructorNavbar />
       <Outlet />
     </div>

--- a/client/src/shared/layout/InstructorLayout.tsx
+++ b/client/src/shared/layout/InstructorLayout.tsx
@@ -4,7 +4,7 @@ import { Outlet } from "react-router";
 
 const InstructorLayout = () => {
   return (
-    <div className="flex h-screen flex-row justify-between">
+    <div className="flex h-screen flex-row gap-3">
       <InstructorNavbar />
       <Outlet />
     </div>


### PR DESCRIPTION
## 🔷 Github Issue ID

[Closes #247]

---
## 📌 작업 내용 및 특이사항
![instructor home](https://github.com/user-attachments/assets/905089f9-a0ca-4969-bd69-e2e43034d4a5)

- 강사가 강의 목록을 볼 수 있는 강사 홈페이지 퍼블리싱했습니다.
- 강좌 생성 버튼을 일단...피그마 상의 디자인과 비슷한 위치에 놓았는데 살짝 어색해보입니다...우측 하단에 동그란 FAB를 두는 건 어떨까요?

---
## 📚 참고사항
- 요청해주신 탭 바는 query에 대한 구현 없이 state에 따라서 탭 컨텐츠가 바뀌도록 구현했습니다. (8ffda7699a186d75d2370a64bbff7cb4a4346533) 탭 라벨, 탭에 따라 보여줄 내용(content)만 props로 넣어주면 됩니다. query 붙이면서 수정사항 생기면 수정사항 공유만 해주시고 마음껏 수정해주세요!
